### PR TITLE
Remove unnecessary LoI section element

### DIFF
--- a/src/epub/text/loi.xhtml
+++ b/src/epub/text/loi.xhtml
@@ -6,32 +6,30 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="backmatter">
-		<section id="loi" epub:type="loi">
-			<nav epub:type="loi">
-				<h2 epub:type="title">List of Illustrations</h2>
-				<ol>
-					<li>
-						<p>
-							<a href="the-fascinating-problem-of-uncle-meleagers-will.xhtml#illustration-1">A crossword puzzle grid with rows numbered with Arabic numerals and columns numbered with Roman numerals. Most cells are black or white, but some additional reddish cells create a square pattern midway to the center of the puzzle.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="the-undignified-melodrama-of-the-bone-of-contention.xhtml#illustration-2">A sketch map of the area near the parish church of Little Doddering. North is to the left, south to the right. At top left is Mortimer’s house and the village of Abbott’s Bolton; middle left is the village of Frimpton. At the center bottom of the map is the village of Petering Friars. Little Doddering, with its old priory is at the right of the map, across the road from the War Memorial. Bridle paths connect Mortimer’s house to a barn and then to Dead Man’s Post, Little Doddering, Petering Friars and the road to Lympton.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="the-learned-adventure-of-the-dragons-head.xhtml#illustration-3">A page from Münster’s Cosmographia Universalis, showing a fanciful map of the discoveries in the New World made by Christopher Columbus. Overwritten on the map are the words: “Hic in capite draconis ardet perpetuo Sol.”</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="solution.xhtml#illustration-4">A crossword puzzle grid with the solution filled in. Revealed on the reddish cells are the words TESTAMENT, VERSICLES, CANTICLES and THIRTYONE.</a>
-						</p>
-					</li>
-				</ol>
-			</nav>
-		</section>
+		<nav id="loi" epub:type="loi">
+			<h2 epub:type="title">List of Illustrations</h2>
+			<ol>
+				<li>
+					<p>
+						<a href="the-fascinating-problem-of-uncle-meleagers-will.xhtml#illustration-1">A crossword puzzle grid with rows numbered with Arabic numerals and columns numbered with Roman numerals. Most cells are black or white, but some additional reddish cells create a square pattern midway to the center of the puzzle.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="the-undignified-melodrama-of-the-bone-of-contention.xhtml#illustration-2">A sketch map of the area near the parish church of Little Doddering. North is to the left, south to the right. At top left is Mortimer’s house and the village of Abbott’s Bolton; middle left is the village of Frimpton. At the center bottom of the map is the village of Petering Friars. Little Doddering, with its old priory is at the right of the map, across the road from the War Memorial. Bridle paths connect Mortimer’s house to a barn and then to Dead Man’s Post, Little Doddering, Petering Friars and the road to Lympton.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="the-learned-adventure-of-the-dragons-head.xhtml#illustration-3">A page from Münster’s Cosmographia Universalis, showing a fanciful map of the discoveries in the New World made by Christopher Columbus. Overwritten on the map are the words: “Hic in capite draconis ardet perpetuo Sol.”</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="solution.xhtml#illustration-4">A crossword puzzle grid with the solution filled in. Revealed on the reddish cells are the words TESTAMENT, VERSICLES, CANTICLES and THIRTYONE.</a>
+					</p>
+				</li>
+			</ol>
+		</nav>
 	</body>
 </html>


### PR DESCRIPTION
Per https://standardebooks.org/manual/1.8.0/7-high-level-structural-patterns#7.9 the `<nav>` should be directly nested under the `<body>`.